### PR TITLE
tasks/all

### DIFF
--- a/app/controllers/public/tasks_controller.rb
+++ b/app/controllers/public/tasks_controller.rb
@@ -50,9 +50,11 @@ class Public::TasksController < ApplicationController
   end
 
   def destroy
-    @task = Task.find(params[:id])
+    #@task = Task.find(params[:id])
+    task_member = TaskMember.find_by(task_id: params[:id], member_id: current_member.id)
+    task_member.destroy
     #current_memberは、@task.membersから消されるという記述。
-    @task.members.delete(current_member)
+    #@task.members.delete(current_member)
     redirect_to tasks_path
   end
 

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -5,7 +5,7 @@ class Member < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_many :task_members, dependent: :destroy
-  has_many :tasks, through: :task_members, dependent: :destroy
+  has_many :tasks, through: :task_members
 
   validates :display_name, presence: true
   validates :user_name, presence: true, uniqueness: true, format: { with: /\A[a-z0-9]+\z/, message: "は半角英数字で入力してください。" }

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,7 +1,7 @@
 class Task < ApplicationRecord
 
   has_many :task_members, dependent: :destroy
-  has_many :members, through: :task_members, dependent: :destroy
+  has_many :members, through: :task_members
 
   validates :task_title, presence: true
   validates :task_content, presence: true

--- a/app/models/task_member.rb
+++ b/app/models/task_member.rb
@@ -1,6 +1,6 @@
 class TaskMember < ApplicationRecord
 
-  belongs_to :member, dependent: :destroy
-  belongs_to :task, dependent: :destroy
+  belongs_to :member
+  belongs_to :task
 
 end


### PR DESCRIPTION
親タスク(グループ)に参加／退出ボタン作成済みで、参加はできるようになったが退出ボタンを押すとエラーは出ないが退出できたりログイン画面にとばされ再度新規登録しないといけない状態になったりします。
解決しました。
dependent: :destroyの記載が間違っていた。
コントローラーのdestroyの記述が間違っていたためでした。